### PR TITLE
[Fix] csrf_cookie_domain 설정 주석 처리

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -73,10 +73,11 @@ MIDDLEWARE = [
 
 CSRF_TRUSTED_ORIGINS = ["localhost:8000"]
 
-CSRF_COOKIE_DOMAIN = "bluemix.net"
+# CSRF_COOKIE_DOMAIN = "bluemix.net"
 
 CORS_ALLOW_HEADERS = [
     "x-csrftoken",
+    "content-type",
 ]
 
 CORS_ALLOW_ALL_ORIGINS = True


### PR DESCRIPTION
csrf_cookie_domain 설정이 cookie_domain을 제한하여 403 문제가 발생해서 주석 처리함