### PR TITLE
[Feat] 게임 로직 수정

### DIFF
--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from django.core.cache import cache
@@ -67,6 +68,7 @@ class GameConsumer(AsyncWebsocketConsumer):
             game_width = data["width"]
             game_height = data["height"]
             self.game_settings(game_width, game_height)
+            await self.start_ball_movement()
 
         elif action == "move_ball":
             self.update_ball_position()
@@ -263,3 +265,9 @@ class GameConsumer(AsyncWebsocketConsumer):
         await self.send(
             text_data=json.dumps({"type": event_type, "data": event["data"]})
         )
+
+    async def start_ball_movement(self):
+        while self.running:
+            await self.update_ball_position()
+            await self.send_ball_position()
+            await asyncio.sleep(0.0625)  # 16 FPS


### PR DESCRIPTION
- tournament 모드를 위해 참가자한테 역할을 부여 (players-참가자, spectators-관전자)
- 초기 세팅에서 패들의 위치가 위쪽,아래쪽 이 아닌 왼쪽, 오른쪽으로 되어 있어 수정
- 게임 시작하면 공의 위치를 계속 클라이언트한테 전송