### PR TITLE
[Refactor] 토너먼트 닉네임 중복검사

### DIFF
--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -114,12 +114,6 @@ class GameConsumer(AsyncWebsocketConsumer):
             await self.game_settings(game_width, game_height)
             asyncio.create_task(self.start_ball_movement())
 
-        elif action == "restart_game":  # update_score 이후에 게임 시작 로직
-            self.running = True
-            self.game_ended = False
-            await self.game_settings(self.game_width, self.game_height)
-            asyncio.create_task(self.start_ball_movement())
-
         elif action == "move_ball":
             self.update_ball_position()
             await self.send_ball_position()

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -11,7 +11,6 @@ from channels.generic.websocket import AsyncWebsocketConsumer
 from .utils import generate_room_name, manage_participants
 from login.authentication import JWTAuthentication, decode_jwt
 from django.contrib.auth.models import AnonymousUser
-from .serializers import NicknameSerializer
 
 from user.models import Member
 
@@ -158,10 +157,9 @@ class GameConsumer(AsyncWebsocketConsumer):
             current_nicknames.append((nickname, realname))
             cache.set(f"{self.room_name}_nicknames", current_nicknames)
             logger.debug(f"current_nicknames: {current_nicknames}")
-        serialized_nicknames = NicknameSerializer(
-            [{"nickname": nick, "realname": real} for nick, real in current_nicknames],
-            many=True,
-        ).data
+        serialized_nicknames = [
+            {"nickname": nick, "realname": real} for nick, real in current_nicknames
+        ]
 
         await self.channel_layer.group_send(
             self.room_group_name,

--- a/backend/game/views.py
+++ b/backend/game/views.py
@@ -18,6 +18,7 @@ from django.core.cache import cache
 
 logger = logging.getLogger(__name__)
 
+
 class GameResultView(APIView):
     permission_classes = [IsAuthenticated]
     parser_classes = [JSONParser]
@@ -30,8 +31,8 @@ class GameResultView(APIView):
     def post(self, request):
         serializer = GameResultSerializer(data=request.data)
         if serializer.is_valid():
-            user1_nickname = serializer.validated_data['user1']
-            user2_nickname = serializer.validated_data['user2']
+            user1_nickname = serializer.validated_data["user1"]
+            user2_nickname = serializer.validated_data["user2"]
 
             user1 = get_object_or_404(Member, nickname=user1_nickname)
             user2 = get_object_or_404(Member, nickname=user2_nickname)
@@ -39,9 +40,9 @@ class GameResultView(APIView):
             game = Game(
                 user1=user1,
                 user2=user2,
-                user1_score=serializer.validated_data['user1_score'],
-                user2_score=serializer.validated_data['user2_score'],
-                game_type=serializer.validated_data['game_type']
+                user1_score=serializer.validated_data["user1_score"],
+                user2_score=serializer.validated_data["user2_score"],
+                game_type=serializer.validated_data["game_type"],
             )
             game.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -65,11 +66,16 @@ class CheckNicknameView(APIView):
         nickname = request.data.get("nickname")
         realname = request.data.get("realname")
         room_name = request.data.get("room_name")
-        logger.debug(f"nickname: {nickname}, realname: {realname}, room_name: {room_name}")
+        logger.debug(
+            f"nickname: {nickname}, realname: {realname}, room_name: {room_name}"
+        )
         participants = cache.get(f"{room_name}_participants", None)
         logger.debug(f"participants: {participants}")
         if participants is None:
-            return Response({"Message": "Room participants not found"}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"Message": "Room participants not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         current_nicknames = cache.get(f"{room_name}_nicknames", set())
 
@@ -81,7 +87,8 @@ class CheckNicknameView(APIView):
             cache.set(f"{room_name}_nicknames", current_nicknames)
 
         serialized_nicknames = NicknameSerializer(
-            [{"nickname": nick, "realname": real} for nick, real in current_nicknames], many=True
+            [{"nickname": nick, "realname": real} for nick, real in current_nicknames],
+            many=True,
         ).data
 
         return Response({"valid": True, "nicknames": serialized_nicknames})


### PR DESCRIPTION
- 토너먼트 닉네임 중복 검사 로직을 API 요청에서 웹소켓 에서 처리 하는걸로 변경완료
- 클라이언트가 나갔을때 _participants 에서 삭제 로직 추가
- 게임이 시작될 때 방의 첫번째 사용자를 클라이언트측으로 알려주기