### PR TITLE
[Feat] 게임 재시작 로직 추가

### DIFF
--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -26,6 +26,28 @@ paddle_speed = 6
 
 
 class GameConsumer(AsyncWebsocketConsumer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # connect
+        self.mode = None
+        self.nickname = None
+        self.room_name = None
+        self.room_group_name = None
+
+        # receive
+        self.game_width = None
+        self.game_height = None
+        self.ball_position = None
+        self.ball_velocity = None
+        self.paddle_width = None
+        self.paddle_height = None
+        self.max_paddle_x = None
+        self.paddles = {}
+        self.scores = {}
+        self.current_participants = []
+        self.running = False
+        self.game_ended = False
+
     async def connect(self):
         # JWT 토큰 확인 및 사용자 인증
         token_key = self.scope["query_string"].decode().split("=")[1]
@@ -40,14 +62,14 @@ class GameConsumer(AsyncWebsocketConsumer):
         self.room_name = await sync_to_async(generate_room_name)(self.mode)
         self.room_group_name = f"game_room_{self.room_name}"
 
-        current_participants = cache.get(f"{self.room_name}_participants", [])
-        if not current_participants:
+        self.current_participants = cache.get(f"{self.room_name}_participants", [])
+        if not self.current_participants:
             cache.set(
-                f"{self.room_name}_participants", current_participants, timeout=3600
+                f"{self.room_name}_participants", self.current_participants, timeout=3600
             )
         # 참가자 추가
-        current_participants.append(self.nickname)
-        cache.set(f"{self.room_name}_participants", current_participants)
+        self.current_participants.append(self.nickname)
+        cache.set(f"{self.room_name}_participants", self.current_participants)
 
         await sync_to_async(manage_participants)(self.room_name, increase=True)
 
@@ -56,7 +78,7 @@ class GameConsumer(AsyncWebsocketConsumer):
 
         max_participants = 2 if self.mode == "REMOTE" else 4
 
-        if len(current_participants) == max_participants:
+        if len(self.current_participants) == max_participants:
             await self.channel_layer.group_send(
                 self.room_group_name,
                 {
@@ -100,6 +122,14 @@ class GameConsumer(AsyncWebsocketConsumer):
             f"Updated participants in {self.room_name}: {current_participants}"
         )
 
+    # todo
+    #       self.running으로 while 돌리는데 다시 게임 시작할 때 이전꺼 종료시키고 다시 새로 시작할 수 있도록 로직 추가
+    #       update_game_score에서 update_score을 다 진행할 거고 여기서 winner, loser 다 보내줘야 함
+    # done
+    #       move_ball, update_score, end_game 삭제
+    #       action == restart_game 로직 추가
+    #       update_score에서 ball_position 초기화 했던 부분 옮기기 (restart_game)
+    #       game_start가 두번 호출되는 문제 해결
     async def receive(self, text_data):
         data = json.loads(text_data)
         action = data["type"]
@@ -110,29 +140,27 @@ class GameConsumer(AsyncWebsocketConsumer):
                 realname = self.nickname
                 await self.check_nickname(nickname, realname)
 
-        elif action == "start_game":  # 프론트에서 보내는거, 처음 게임 시작만 반응
-            # 프론트에서 window의 width, height 받음
-            game_width = data["width"]
-            game_height = data["height"]
-            await self.game_settings(game_width, game_height)
+        elif action == "start_game":
+            if self.running:
+                return
+            await self.game_settings(data["width"], data["height"])
             asyncio.create_task(self.start_ball_movement())
 
-        elif action == "move_ball":
-            self.update_ball_position()
-            await self.send_ball_position()
+        elif action == "restart_game":
+            if self.running:
+                return
+            await self.init_data()
+            await self.send_game_data("game_restart")
+            self.running = True
+            asyncio.create_task(self.start_ball_movement())
 
         elif action == "move_paddle":
-            paddle = data["paddle"]
+            if not self.running:
+                return
+            paddle_owner = data["paddle"]
             direction = data["direction"]
-            await self.move_paddle(paddle, direction)
+            await self.move_paddle(paddle_owner, direction)
             await self.send_paddle_position()
-
-        elif action == "update_score":
-            player_id = data["player_id"]
-            await self.update_game_score(player_id)
-
-        elif action == "end_game":
-            await self.end_game()
 
     async def check_nickname(self, nickname, realname):
         participants = cache.get(f"{self.room_name}_participants", [])
@@ -180,41 +208,48 @@ class GameConsumer(AsyncWebsocketConsumer):
         )
 
     async def game_settings(self, game_width, game_height):
+        self.running = True
+
         self.game_width = game_width
         self.game_height = game_height
-        self.ball_position = {"x": self.game_width / 2, "y": self.game_height / 2}
-        self.ball_velocity = {"x": 5, "y": 5}
         self.paddle_width = paddle_width
         self.paddle_height = grid
         self.max_paddle_x = self.game_width - 15 - self.paddle_width
 
         # 참가자 목록을 캐시에서 불러오기
-        current_participants = cache.get(f"{self.room_name}_participants", [])
+        self.current_participants = cache.get(f"{self.room_name}_participants", [])
 
-        self.paddles = []
-        if len(current_participants) >= 2:
-            self.paddles.append(
-                {
-                    "nickname": current_participants[0],
-                    "x": self.game_width / 2 - self.paddle_width / 2,
-                    "y": self.game_height - grid * 3,
-                    "width": self.paddle_width,
-                    "height": grid,
-                }
-            )
-            self.paddles.append(
-                {
-                    "nickname": current_participants[1],
-                    "x": self.game_width / 2 - self.paddle_width / 2,
-                    "y": grid * 2,
-                    "width": self.paddle_width,
-                    "height": grid,
-                }
-            )
-        self.scores = {nickname: 0 for nickname in current_participants}
-        self.running = True
+        # 게임 시작하기 직전에 방 나간 경우(?)
+        if len(self.current_participants) < 2:
+            self.running = False
+            self.game_ended = True
+            return
+
+        # game_data 설정해서 보내주기
+        await self.init_data()
+        self.scores = {nickname: 0 for nickname in self.current_participants}
         self.game_ended = False
+        await self.send_game_data("game_start")
 
+    async def init_data(self):
+        self.ball_position = {"x": self.game_width / 2, "y": self.game_height / 2}
+        self.ball_velocity = {"x": 5, "y": 5}
+        self.paddles[self.current_participants[0]] = {
+            "nickname": self.current_participants[0],
+            "x": self.game_width / 2 - self.paddle_width / 2,
+            "y": self.game_height - grid * 3,
+            "width": self.paddle_width,
+            "height": grid,
+        }
+        self.paddles[self.current_participants[1]] = {
+            "nickname": self.current_participants[1],
+            "x": self.game_width / 2 - self.paddle_width / 2,
+            "y": grid * 2,
+            "width": self.paddle_width,
+            "height": grid,
+        }
+
+    async def send_game_data(self, event_type):
         game_data = {
             "ball_position": self.ball_position,
             "ball_velocity": self.ball_velocity,
@@ -224,8 +259,13 @@ class GameConsumer(AsyncWebsocketConsumer):
 
         await self.channel_layer.group_send(
             self.room_group_name,
-            {"type": "broadcast_event", "event_type": "game_start", "data": game_data},
+            {
+                "type": "broadcast_event",
+                "event_type": event_type,
+                "data": game_data
+            },
         )
+
 
     async def send_ball_position(self):
         await self.channel_layer.group_send(
@@ -270,14 +310,14 @@ class GameConsumer(AsyncWebsocketConsumer):
 
         await self.check_paddle_collision()
 
-    async def move_paddle(self, paddle, direction):
+    async def move_paddle(self, paddle_owner, direction):
         if direction == "left":
-            self.paddles[paddle]["x"] = max(
-                grid, self.paddles[paddle]["x"] - paddle_speed
+            self.paddles[paddle_owner]["x"] = max(
+                grid, self.paddles[paddle_owner]["x"] - paddle_speed
             )
         elif direction == "right":
-            self.paddles[paddle]["x"] = min(
-                self.max_paddle_x, self.paddles[paddle]["x"] + paddle_speed
+            self.paddles[paddle_owner]["x"] = min(
+                self.max_paddle_x, self.paddles[paddle_owner]["x"] + paddle_speed
             )
 
     async def check_paddle_collision(self):
@@ -314,42 +354,32 @@ class GameConsumer(AsyncWebsocketConsumer):
             ball_velocity["x"] = (hit_pos - 0.5) * 2 * ball_speed
 
     async def update_game_score(self, player):
-        for score in self.scores:
-            if score["nickname"] == player:
-                score["score"] += 1
-            if self.scores[player] >= 7:  # 게임 종료 조건
-                self.running = False
-                self.game_ended = True
-                await self.end_game(player)
-                return  # 점수 업데이트 후 나머지 로직은 실행하지 않음
+        self.running = False
+        self.scores[player] += 1
+        if self.scores[player] >= 7:  # 게임 종료 조건(end_game 여기서만 call)
+            await self.end_game(player)
+        else:
+            # init부분 삭제
+            self.ball_position = {"x": self.game_width / 2, "y": self.game_height / 2}
+            self.ball_velocity = {"x": ball_speed, "y": ball_speed}
+            # 패들 위치
 
-        self.ball_position = {"x": self.game_width / 2, "y": self.game_height / 2}
-        self.ball_velocity = {"x": ball_speed, "y": ball_speed}
+            game_score = {
+                "scores": self.scores,
+                "ball_position": self.ball_position,
+                "ball_velocity": self.ball_velocity,
+            }
 
-        for paddle in self.paddles:
-            paddle["x"] = self.game_width / 2 - self.paddle_width / 2
-            if paddle["nickname"] == self.paddles[0]["nickname"]:
-                paddle["y"] = self.game_height - grid * 3  # 하단 패들 초기 위치
-            else:
-                paddle["y"] = grid * 2  # 상단 패들 초기 위치
-        game_score = {
-            "scores": self.scores,
-            "ball_position": self.ball_position,
-            "ball_velocity": self.ball_velocity,
-            "paddles": self.paddles,
-        }
-
-        await self.channel_layer.group_send(
-            self.room_group_name,
-            {
-                "type": "broadcast_event",
-                "event_type": "update_score",
-                "data": game_score,
-            },
-        )
+            await self.channel_layer.group_send(
+                self.room_group_name,
+                {
+                    "type": "broadcast_event",
+                    "event_type": "update_score",
+                    "data": game_score,
+                },
+            )
 
     async def end_game(self, winner):
-        self.running = False
         self.game_ended = True
 
         end_game_data = {


### PR DESCRIPTION
### done!
- action == restart_game 로직 추가
- 내부에서 전역처럼 사용했던 변수들 생성자 따로 만들어서 미리 선언해서 사용하도록 변경
- 변수 중 이전에 형준님이 set으로 했던 내용 ignore하고 다시 list로 진행(유저 이름으로 구분했기 때문)
- update_score에서 ball_position 초기화 했던 부분 옮기기 (restart_game)
- self.running으로 while 돌리는데 다시 게임 시작할 때 이전꺼 종료시키고 다시 새로 시작할 수 있도록 로직 추가
- update_score에서 winner와 함께 loser도 보내도록 추가
- start_game을 한번만 실행했었지만 running이 나머지 클라이언트에서 세팅이 되지 않았던 문제가 있었음
   -> 프론트에서 running_user를 선별해서 주면 start_game에서 이를 확인하고 한번만 루프 서버를 돌리도록 하고 나머지 세팅은 모두 다 적용되도록 추가함