### PR TITLE
[Fix] 볼의 움직임이 막히던 버그 수정

### DIFF
--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -335,13 +335,13 @@ class GameConsumer(AsyncWebsocketConsumer):
         ball = self.ball_position
         ball_velocity = self.ball_velocity
 
-        if self.current_participants[0] in self.paddles:
-            top_paddle = self.paddles[self.current_participants[0]]
+        if self.current_participants[1] in self.paddles:
+            top_paddle = self.paddles[self.current_participants[1]]
         else:
             top_paddle = None
 
-        if self.current_participants[1] in self.paddles:
-            bottom_paddle = self.paddles[self.current_participants[1]]
+        if self.current_participants[0] in self.paddles:
+            bottom_paddle = self.paddles[self.current_participants[0]]
         else:
             bottom_paddle = None
 


### PR DESCRIPTION
설명
- 볼이 벽끝까지 안가고 막히던 버그가 있었음
- paddle이 볼에 닿을때를 처리하던 check_paddle_collision에서 paddle의 위치가 잘못 들어가 있었음
- top_paddle과 bottom_paddle의 위치를 바꿔서 해결