### PR TITLE
[Feat] 토너먼트 몰수패 처리

### DIFF
--- a/backend/login/views.py
+++ b/backend/login/views.py
@@ -239,10 +239,7 @@ class TwoFactorVerifyCodeView(APIView):
         user = request.user
         stored_code = cache.get(f"2fa_code_{user.nickname}")
         if not stored_code or stored_code != verification_code:
-            return Response(
-                {"error": "Invalid or expired 2FA code"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+            return Response({"error": "Invalid or expired 2FA code"})
 
         # delete stored-code from cache
         cache.delete(f"2fa_code_{user.nickname}")


### PR DESCRIPTION
### done

<첫번째 게임 후>
*(`disconnect`에서 처리할 부분 있음 → 관전자는 end_game에 접근 할 수 없기 때문에 본인을 loser와 나머지 관전자에 대해 winner 세팅을 하는 로직이 추가적으로 필요하기 때문)*
1. 관전자가 1명 나간 경우. → winners배열에 1명 있고, spectator에 1명 있는 경우 → `end_game`에서 결승 시작하도록
    1. 남은 관전자를 바로 winners 배열에 넣기 → `disconnect` 에서 함
2. 관전자가 2명 다 나간경우 → winners에 있는 한명이 최종 우승
    1. winners에 있는 1명을 바로 우승자로 만든다. → winners배열에 1명 있고, spectator에 0명 있는 경우 → 이건 이미 1에서 처리해서 추가적으로 추가할 필요 없음

<두번째 게임 후>
*(`disconnect`에서 처리할 필요 없음 → 이미 전 게임 결과에서 winner와 loser가 저장되어 있기 때문)*
1. 관전자 중 winner가 나간 경우 → 이 경우는 game_setting에서 추가적으로 진행함
    1. current_player에 사라지니까 이 부분을 확인해서 진행 
    → winners len을 확인해서 ≠ 1 이라면 두번째 경기의 winner가 최종 우승자
    → 두번째 경기의 우승자를 winners에 넣었는데 len이 ≠2 면 winners[0]이 최종 우승자
2. 관전자 중 loser가 나간 경우 → 생각 안해도 됨

<결승 직전>
1. 플레이어 둘 다 나간 경우 → 화면 상 `unknown`으로 뜨고 있음(프론트에서 처리하기로 함)

### todo
- 반드시 리펙토링 필요(중복 코드 굉장히 많음)