### PR TITLE
[Fix] 몰수패 처리 수정

### DIFF
--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -146,10 +146,10 @@ class GameConsumer(AsyncWebsocketConsumer):
 
         if self.nickname in users["players"]:  # players가 나간 경우
             opponent = next(p for p in users["players"] if p != self.nickname)
-            GameConsumer.running[self.room_name] = False
             self.scores[opponent] = 7
             if GameConsumer.running[self.room_name] == True:
                 await self.end_game(opponent, self.nickname)
+            GameConsumer.running[self.room_name] = False
         elif len(users["spectators"]) == 2:  # spectators가 1명 나간 경우
             # 남은 spectators가 winner (남은 spectators가 나가더라도 winner는 이미 여기서 정해짐)
             winner = next(

--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -410,10 +410,11 @@ class GameConsumer(AsyncWebsocketConsumer):
         ball_velocity = self.ball_velocity
 
         current_participants = cache.get(f"{self.room_name}_participants")
-        if current_participants["players"][1] in self.paddles:
-            top_paddle = self.paddles[current_participants["players"][1]]
-        else:
-            top_paddle = None
+        if len(current_participants["players"]) == 2:
+            if current_participants["players"][1] in self.paddles:
+                top_paddle = self.paddles[current_participants["players"][1]]
+            else:
+                top_paddle = None
 
         if current_participants["players"][0] in self.paddles:
             bottom_paddle = self.paddles[current_participants["players"][0]]
@@ -552,6 +553,7 @@ class GameConsumer(AsyncWebsocketConsumer):
         )
         winners = cache.get(f"{self.room_name}_winners", [])
         losers = cache.get(f"{self.room_name}_losers", [])
+        round_type = "next_round"
 
         if len(current_participants["spectators"]) == 2:  # 4강 2경기
             # players 애들을 winners, losers 배열 만들고 이동
@@ -574,7 +576,7 @@ class GameConsumer(AsyncWebsocketConsumer):
                 self.room_group_name,
                 {
                     "type": "broadcast_next_tournament",
-                    "event_type": "next_round",  # next_round
+                    "event_type": round_type,  # next_round
                     "running_user_nickname": new_running_user,
                 },
             )
@@ -582,6 +584,7 @@ class GameConsumer(AsyncWebsocketConsumer):
             len(winners) == 1 and len(current_participants["spectators"]) == 0
         ):  # 파이널
             GameConsumer.is_final[self.room_name] = True
+            round_type = "final_round"
             winners.append(winner)
             losers.append(loser)
             cache.set(f"{self.room_name}_winners", winners)
@@ -602,7 +605,7 @@ class GameConsumer(AsyncWebsocketConsumer):
                 self.room_group_name,
                 {
                     "type": "broadcast_next_tournament",
-                    "event_type": "next_round",  # next_round
+                    "event_type": round_type,  # final_round
                     "running_user_nickname": new_running_user,
                 },
             )
@@ -610,6 +613,7 @@ class GameConsumer(AsyncWebsocketConsumer):
             len(winners) == 1 and len(current_participants["spectators"]) == 1
         ):  # 첫번째 게임 후 1번경우
             GameConsumer.is_final[self.room_name] = True
+            round_type = "final_round"
             winners.append(winner)
             losers.append(loser)
             cache.set(f"{self.room_name}_winners", winners)
@@ -623,7 +627,7 @@ class GameConsumer(AsyncWebsocketConsumer):
                 self.room_group_name,
                 {
                     "type": "broadcast_next_tournament",
-                    "event_type": "next_round",  # next_round
+                    "event_type": round_type,  # final_round
                     "running_user_nickname": new_running_user,
                 },
             )


### PR DESCRIPTION
### done
- 게임이 끝나도 player가 나갈 때 몰수패가 한번 더 뜨는 것을 방지하기 위해 end_game 호출 제한에 조건을 걸었는데 running에 대한 flag 설정하는 부분 위치 조정
- 토너먼트 결승이 몰수패 두명이 올라오는 경우 게임 시작이 안되는 문제 해결
- cache에서 current_participants를 가지고 와 인덱스로 접근하고 할 때, 2명이 아닌 경우 index_error 발생에 대비한 조건 추가
- round_type에 대해 기존 `next_round`에 대해 `final_round` 추가