### PR TITLE
[Feat] 게임방에 최대 인원보다 작으면 그 방으로 찾아 들어가는 이슈 해결

### DIFF
--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -439,13 +439,6 @@ class GameConsumer(AsyncWebsocketConsumer):
     async def end_game(self, winner, loser):
         GameConsumer.running[self.room_name] = False
         self.running_user = False
-
-        # rooms = cache.get("rooms", {})
-        # room_details = rooms.get(self.room_name, {})
-        # room_details["in_game"] = False
-        # rooms[self.room_name] = room_details
-        # cache.set("rooms", rooms)
-
         await self.send_end_game_data(winner, loser)
 
         # prepare for only next_round

--- a/backend/game/utils.py
+++ b/backend/game/utils.py
@@ -10,9 +10,16 @@ def generate_room_name(mode):
     rooms = cache.get("rooms", {})
 
     # 각 방에 대한 정보에 모드도 포함(count는 현재 참여자 수, max는 모드에 따라 최대 참가자 수)
-    if not rooms or all(rooms[r]["count"] == rooms[r]["max"] for r in rooms):
+    if not rooms or all(
+        rooms[r]["count"] == rooms[r]["max"] or rooms[r]["in_game"] for r in rooms
+    ):
         new_room_name = secrets.token_urlsafe(8)
-        rooms[new_room_name] = {"count": 0, "max": max_participants, "mode": mode}
+        rooms[new_room_name] = {
+            "count": 0,
+            "max": max_participants,
+            "mode": mode,
+            "in_game": False,
+        }
         cache.set("rooms", rooms)
         return new_room_name
     else:
@@ -20,12 +27,19 @@ def generate_room_name(mode):
             return next(
                 r
                 for r in rooms
-                if rooms[r]["count"] < rooms[r]["max"] and rooms[r]["mode"] == mode
+                if rooms[r]["count"] < rooms[r]["max"]
+                and rooms[r]["mode"] == mode
+                and not rooms[r]["in_game"]
             )
         except StopIteration:
             # 모든 방이 꽉 찼거나, 조건에 맞는 방이 없는 경우 새로운 방 생성
             new_room_name = secrets.token_urlsafe(8)
-            rooms[new_room_name] = {"count": 0, "max": max_participants, "mode": mode}
+            rooms[new_room_name] = {
+                "count": 0,
+                "max": max_participants,
+                "mode": mode,
+                "in_game": False,
+            }
             cache.set("rooms", rooms)
             return new_room_name
 


### PR DESCRIPTION
- 게임을 찾을 때 그 방의 최대인원보다 작으면 무조건 그 방으로 찾아가는 이슈가 있어 그 로직 수정
- 방 만들때 게임 시작 여부를 True/False로 관리
- 게임 세팅 시 False->True로 변경

- paddle 색 프론트에게 처리하기로 해서 그 로직 삭제