### PR TITLE
[Fix] disconnect시 spectators에 쌓이는 문제 해결

### DIFF
--- a/backend/game/consumers.py
+++ b/backend/game/consumers.py
@@ -165,15 +165,26 @@ class GameConsumer(AsyncWebsocketConsumer):
             cache.set(f"{self.room_name}_losers", losers)
 
     def remove_nickname_from_cache(self):
+        logger.debug(
+            f"==============remove_nickname_from_cache: {self.nickname}=============="
+        )
         current_nicknames = cache.get(f"{self.room_name}_nicknames", [])
+        logger.debug(f"before remove current_NICK: {current_nicknames}")
         nickname = self.scope["user"].nickname
         current_nicknames = [n for n in current_nicknames if n[1] != nickname]
         cache.set(f"{self.room_name}_nicknames", current_nicknames)
+        logger.debug(f"after remove current_NICK: {current_nicknames}")
 
     def remove_participant_from_cache(self):
+        logger.debug(
+            f"==============remove_participant_from_cache: {self.nickname}=============="
+        )
         current_participants = cache.get(f"{self.room_name}_participants", None)
         if not current_participants:
             return
+
+        logger.debug(f"before remove current_participants: {current_participants}")
+        # nickname = self.scope["user"].nickname
 
         # players 또는 spectators에서 self.nickname 삭제
         current_participants["players"] = [
@@ -238,12 +249,14 @@ class GameConsumer(AsyncWebsocketConsumer):
     async def check_nickname(self, tournament_nickname, nickname):
         current_participants = cache.get(f"{self.room_name}_participants")
         current_nicknames = cache.get(f"{self.room_name}_nicknames", [])
+        # delete!!!!!!!!!!!!!!!!!!
         logger.debug("==============CHECK NICKNAME==============")
         logger.debug(f"accepted tournament-nickname: {tournament_nickname}")
-        logger.debug(f"current_NICKnames: {current_nicknames}")
-        logger.debug(f"current_participants: {current_participants}")
+        logger.debug(f"before append -> current_nicknames: {current_nicknames}")
+        logger.debug(f"before change -> current_participants: {current_participants}")
 
         if any(nick == tournament_nickname for nick, _ in current_nicknames):
+            logger.debug(f"{tournament_nickname} is in nicknames!! request again!!")
             await self.send(text_data=json.dumps({"valid": False}))
             return
 
@@ -295,6 +308,12 @@ class GameConsumer(AsyncWebsocketConsumer):
                     },
                 },
             )
+
+        logger.debug("--------------after update--------------")
+        logger.debug(f"accepted tournament-nickname: {tournament_nickname}")
+        logger.debug(f"after append -> current_nicknames: {current_nicknames}")
+        logger.debug(f"after change -> current_participants: {current_participants}")
+        logger.debug("==========================================")
         self.nickname = tournament_nickname  # 토너먼트면 self.nickname까지 tournament_nickname으로 변경
 
         await self.send_nickname_validation(current_nicknames)


### PR DESCRIPTION
### done
- 토너먼트에서 게임 시작 전, 방에서 나가면 current_participants가 업데이트되지 않는 문제 해결
(4명이 되면 nickname을 입력받은 tournament_nickname으로 업데이트하는 로직이었으나 self.nickname과 비교했을 때 삭제되지 않는 문제가 생겨서 이 로직을 수정)

### todo
- 토너먼트 게임 시작 전, 방에서 나갈 때 player가 나가면 spectators에 있던 한명이 앞으로 옮겨지는 형태로 진행되어야 하는데 이 부분 수정했다가 게임 진행에 차질이 생겨서 나중에 다시 처리할 예정